### PR TITLE
Add metric query endpoint

### DIFF
--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -45,12 +45,15 @@ fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
 #[get("/?<offset>")]
 fn query_metric_route(offset: Option<&RawStr>) -> Json<Vec<Metric>> {
     let db_conn = establish_connection();
-    let metric_id: i32 = 0;
+    let mut metric_id: i32 = 0;
 
-    // if offset.is_some() {
-    //     metric_id = offset.unwrap().url_decode();
-    // }
-    // https://api.rocket.rs/v0.3/rocket/http/struct.RawStr.html
+    if offset.is_some() {
+        let result = offset.unwrap().url_decode();
+        // https://api.rocket.rs/v0.3/rocket/http/struct.RawStr.html
+        if result.is_ok() {
+            metric_id = result.ok().unwrap().parse().unwrap();
+        }
+    }
 
     let results = metrics::table.filter(metrics::id.gt(metric_id))
         .order(metrics::id)

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -27,7 +27,6 @@ fn ping() -> &'static str {
     "pong"
 }
 
-
 #[post("/", data = "<metric_body>")]
 fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
     let new_metric: NewMetric = metric_body.into_inner();
@@ -41,6 +40,23 @@ fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
     Json(result)
 }
 
+
+use rocket::http::RawStr;
+
+#[get("/?<offset>")]
+fn query_metric_route(offset: Option<&RawStr>) -> Json<Vec<Metric>> {
+    let db_conn = establish_connection();
+    let metric_id = offset;
+
+    let results = metrics::table.filter(metrics::id.eq(9))
+        .order(metrics::id)
+        .limit(10)
+        .load::<Metric>(&db_conn)
+        .expect("Error loading metrics");
+
+    Json(results)
+}
+
 fn main() {
     println!("### Enter the Metrix ###");
     let db_conn = establish_connection();
@@ -51,6 +67,6 @@ fn main() {
 
     rocket::ignite()
         .mount("/ping", routes![ping])
-        .mount("/metrics", routes![create_metric_route])
+        .mount("/metrics", routes![create_metric_route, query_metric_route])
         .launch();
 }

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -77,7 +77,7 @@ fn query_metric_route(
             if created_at_start_parsed.is_ok() {
                 filter_clause.insert_str(
                     filter_clause.len(),
-                    &format!(" AND created_at > '{}'", created_at_start).to_string()
+                    &format!(" AND created_at >= '{}'", created_at_start).to_string()
                 );
             }
         }
@@ -95,7 +95,7 @@ fn query_metric_route(
             if created_at_end_parsed.is_ok() {
                 filter_clause.insert_str(
                     filter_clause.len(),
-                    &format!(" AND created_at < '{}'", created_at_end).to_string()
+                    &format!(" AND created_at <= '{}'", created_at_end).to_string()
                 );
             }
         }

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -21,6 +21,8 @@ use lib::establish_connection;
 use schema::metrics;
 use models::*;
 use rocket_contrib::json::Json;
+use rocket::http::RawStr;
+
 
 #[get("/")]
 fn ping() -> &'static str {
@@ -40,15 +42,17 @@ fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
     Json(result)
 }
 
-
-use rocket::http::RawStr;
-
 #[get("/?<offset>")]
 fn query_metric_route(offset: Option<&RawStr>) -> Json<Vec<Metric>> {
     let db_conn = establish_connection();
-    let metric_id = offset;
+    let metric_id: i32 = 0;
 
-    let results = metrics::table.filter(metrics::id.eq(9))
+    // if offset.is_some() {
+    //     metric_id = offset.unwrap().url_decode();
+    // }
+    // https://api.rocket.rs/v0.3/rocket/http/struct.RawStr.html
+
+    let results = metrics::table.filter(metrics::id.gt(metric_id))
         .order(metrics::id)
         .limit(10)
         .load::<Metric>(&db_conn)

--- a/metrix/src/models.rs
+++ b/metrix/src/models.rs
@@ -2,9 +2,8 @@ use super::schema::metrics;
 use serde_json;
 use chrono::naive::NaiveDateTime;
 
-#[derive(Serialize, Deserialize, Queryable)]
-// #[table_name="metrics"] -- idk why it throws compile error
-// "error: cannot find attribute `table_name` in this scope" ...
+#[derive(Serialize, Deserialize, Queryable, QueryableByName)]
+#[table_name="metrics"]
 pub struct Metric {
     pub id: i32,
     pub metric_name: String,


### PR DESCRIPTION
## Work items
- [x] `offset` pagination (W E B S C A L E)
- [x] datetime range query (`start_datetime` - `end_datetime`)
- [x] json-path selection of arbitrary data is _NOT_ part of this PR

Query format:
`/metrics?offset=4&start_datetime=2019-11-11T01:10:00&end_datetime=2019-11-11T01:18:00`

It works with any combination of the 3 parameters.


## Dev Notes (historical):
Originally tried to do dynamic query segments using the ORM using `Box` and `BoxableExpression` types (see [SO answer here](https://stackoverflow.com/questions/48696290/creating-diesel-rs-queries-with-a-dynamic-number-of-ands)).

It was very complicated, but moreover we found out that json operators haven't yet been implemented for `diesel` yet. See https://github.com/diesel-rs/diesel/issues/44.

So we instead are going with `sql_query(...)` to generate a raw SQL query. Luckily diesel provides a `QueryableByName` to still figure out the queried result can be directly instantiated into diesel Model types. 👌 