### PR TITLE
Refactored for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,11 @@ server: ## start docker/server
 	test -f /.dockerenv || docker-compose run --service-ports --rm --name metrix metrix bash || true
 	test -f /.dockerenv && ./run.sh
 
+build: ## just build the app
+	test -f /.dockerenv && cd metrix && cargo build
+
+test: ## run cargo tests
+	test -f /.dockerenv && cd metrix && cargo test
+
 shell: ## jump into server container
 	test -f /.dockerenv || docker exec -it metrix bash

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 .PHONY: help server
 
 help: ## Show all the available make commands
-	@echo "======================================================================================================================================================================="
+	@echo "\n======================================================================================================================================================================="
 	@awk '/```ascii/{a=1; next}/```/{a=0}(a==1){print}' README.md
-	@echo "=======================================================================================================================================================================\n\n"
+	@echo "=======================================================================================================================================================================\n"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 server: ## start docker/server
@@ -15,8 +15,8 @@ server: ## start docker/server
 build: ## just build the app
 	test -f /.dockerenv && cd metrix && cargo build
 
-test: ## run cargo tests
-	test -f /.dockerenv && cd metrix && cargo test
+tests: ## run cargo tests
+	test -f /.dockerenv && ./test.sh
 
 shell: ## jump into server container
 	test -f /.dockerenv || docker exec -it metrix bash

--- a/metrix/src/app.rs
+++ b/metrix/src/app.rs
@@ -1,0 +1,104 @@
+// "Re-exports important traits and types.
+// Meant to be glob imported when using Diesel."
+use diesel::prelude::*;
+
+use crate::lib::establish_connection;
+use crate::schema::metrics;
+use crate::models::*;
+
+use rocket_contrib::json::Json;
+use rocket::http::RawStr;
+use chrono::naive::NaiveDateTime;
+use diesel::sql_query;
+
+
+#[get("/")]
+fn ping() -> &'static str {
+    "pong"
+}
+
+#[post("/", data = "<metric_body>")]
+fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
+    let new_metric: NewMetric = metric_body.into_inner();
+    let db_conn = establish_connection();
+
+    let result: Metric = diesel::insert_into(metrics::table)
+        .values(&new_metric)
+        .get_result(&db_conn)
+        .expect("Error saving new metric");
+
+    Json(result)
+}
+
+#[get("/?<offset>&<start_datetime>&<end_datetime>")]
+fn query_metric_route(
+    offset: Option<&RawStr>,
+    start_datetime: Option<&RawStr>,
+    end_datetime: Option<&RawStr>,
+) -> Json<Vec<Metric>> {
+    let db_conn = establish_connection();
+    let mut filter_clause = String::from("WHERE 1=1");
+
+    if offset.is_some() {
+        let result = offset.unwrap().url_decode();
+        // https://api.rocket.rs/v0.3/rocket/http/struct.RawStr.html
+        if result.is_ok() {
+            let metric_id_str: String = result.ok().unwrap();
+            filter_clause.insert_str(
+                filter_clause.len(),
+                &format!(" AND id > {}", metric_id_str).to_string()
+            );
+        }
+    }
+
+    if start_datetime.is_some() {
+        let result = start_datetime.unwrap().url_decode();
+        if result.is_ok() {
+            let created_at_start = result.ok().unwrap();
+            let created_at_start_parsed = NaiveDateTime::parse_from_str(
+                &created_at_start,
+                &"%Y-%m-%dT%H:%M:%S".to_string() // "2014-5-17T12:34:56"
+            );
+
+            if created_at_start_parsed.is_ok() {
+                filter_clause.insert_str(
+                    filter_clause.len(),
+                    &format!(" AND created_at >= '{}'", created_at_start).to_string()
+                );
+            }
+        }
+    }
+
+    if end_datetime.is_some() {
+        let result = end_datetime.unwrap().url_decode();
+        if result.is_ok() {
+            let created_at_end = result.ok().unwrap();
+            let created_at_end_parsed = NaiveDateTime::parse_from_str(
+                &created_at_end,
+                &"%Y-%m-%dT%H:%M:%S".to_string() // "2014-5-17T12:34:56"
+            );
+
+            if created_at_end_parsed.is_ok() {
+                filter_clause.insert_str(
+                    filter_clause.len(),
+                    &format!(" AND created_at <= '{}'", created_at_end).to_string()
+                );
+            }
+        }
+    }
+
+    println!("### QUERY: SELECT * FROM metrics {};", filter_clause);
+
+    let query_string = format!("SELECT * FROM metrics {} ORDER BY id LIMIT 10", filter_clause);
+    let results = sql_query(query_string)
+        .load(&db_conn)
+        .expect("Error loading metrics");
+
+    Json(results)
+}
+
+pub fn create_app() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/ping", routes![ping])
+        .mount("/metrics", routes![create_metric_route, query_metric_route])
+}

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -7,109 +7,14 @@ extern crate chrono;
 extern crate rocket_contrib;
 extern crate serde_json;
 
-// needed for Diesel stuff?
-// "Re-exports important traits and types. Meant to be glob imported when using Diesel."
-use diesel::prelude::*;
-
 embed_migrations!();
 
 pub mod lib;
 pub mod models;
 pub mod schema;
+pub mod app;
 
 use lib::establish_connection;
-use schema::metrics;
-use models::*;
-use rocket_contrib::json::Json;
-use rocket::http::RawStr;
-use chrono::naive::NaiveDateTime;
-use diesel::sql_query;
-
-
-#[get("/")]
-fn ping() -> &'static str {
-    "pong"
-}
-
-#[post("/", data = "<metric_body>")]
-fn create_metric_route(metric_body: Json<NewMetric>) -> Json<Metric> {
-    let new_metric: NewMetric = metric_body.into_inner();
-    let db_conn = establish_connection();
-
-    let result: Metric = diesel::insert_into(metrics::table)
-        .values(&new_metric)
-        .get_result(&db_conn)
-        .expect("Error saving new metric");
-
-    Json(result)
-}
-
-#[get("/?<offset>&<start_datetime>&<end_datetime>")]
-fn query_metric_route(
-    offset: Option<&RawStr>,
-    start_datetime: Option<&RawStr>,
-    end_datetime: Option<&RawStr>,
-) -> Json<Vec<Metric>> {
-    let db_conn = establish_connection();
-    let mut filter_clause = String::from("WHERE 1=1");
-
-    if offset.is_some() {
-        let result = offset.unwrap().url_decode();
-        // https://api.rocket.rs/v0.3/rocket/http/struct.RawStr.html
-        if result.is_ok() {
-            let metric_id_str: String = result.ok().unwrap();
-            filter_clause.insert_str(
-                filter_clause.len(),
-                &format!(" AND id > {}", metric_id_str).to_string()
-            );
-        }
-    }
-
-    if start_datetime.is_some() {
-        let result = start_datetime.unwrap().url_decode();
-        if result.is_ok() {
-            let created_at_start = result.ok().unwrap();
-            let created_at_start_parsed = NaiveDateTime::parse_from_str(
-                &created_at_start,
-                &"%Y-%m-%dT%H:%M:%S".to_string() // "2014-5-17T12:34:56"
-            );
-
-            if created_at_start_parsed.is_ok() {
-                filter_clause.insert_str(
-                    filter_clause.len(),
-                    &format!(" AND created_at >= '{}'", created_at_start).to_string()
-                );
-            }
-        }
-    }
-
-    if end_datetime.is_some() {
-        let result = end_datetime.unwrap().url_decode();
-        if result.is_ok() {
-            let created_at_end = result.ok().unwrap();
-            let created_at_end_parsed = NaiveDateTime::parse_from_str(
-                &created_at_end,
-                &"%Y-%m-%dT%H:%M:%S".to_string() // "2014-5-17T12:34:56"
-            );
-
-            if created_at_end_parsed.is_ok() {
-                filter_clause.insert_str(
-                    filter_clause.len(),
-                    &format!(" AND created_at <= '{}'", created_at_end).to_string()
-                );
-            }
-        }
-    }
-
-    println!("### QUERY: SELECT * FROM metrics {};", filter_clause);
-
-    let query_string = format!("SELECT * FROM metrics {} ORDER BY id LIMIT 10", filter_clause);
-    let results = sql_query(query_string)
-        .load(&db_conn)
-        .expect("Error loading metrics");
-
-    Json(results)
-}
 
 fn main() {
     println!("### Enter the Metrix ###");
@@ -119,8 +24,5 @@ fn main() {
     let result = embedded_migrations::run(&db_conn);
     println!("### migration done; result: {}", result.is_ok());
 
-    rocket::ignite()
-        .mount("/ping", routes![ping])
-        .mount("/metrics", routes![create_metric_route, query_metric_route])
-        .launch();
+    app::create_app().launch();
 }

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -16,6 +16,10 @@ pub mod app;
 
 use lib::establish_connection;
 
+pub fn create_app() -> rocket::Rocket {
+  app::create_app()
+}
+
 fn main() {
     println!("### Enter the Metrix ###");
     let db_conn = establish_connection();
@@ -24,5 +28,22 @@ fn main() {
     let result = embedded_migrations::run(&db_conn);
     println!("### migration done; result: {}", result.is_ok());
 
-    app::create_app().launch();
+    create_app().launch();
+}
+
+#[cfg(test)]
+mod test {
+    use super::create_app;
+    use rocket::local::Client;
+    use rocket::http::Status;
+
+    #[test]
+    fn ping_me_baby() {
+      let client = Client::new(create_app()).expect("valid rocket instance");
+
+      let mut response = client.get("/ping").dispatch();
+
+      assert_eq!(response.status(), Status::Ok);
+      assert_eq!(response.body_string(), Some("pong".into()));
+    }
 }

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -31,19 +31,4 @@ fn main() {
     create_app().launch();
 }
 
-#[cfg(test)]
-mod test {
-    use super::create_app;
-    use rocket::local::Client;
-    use rocket::http::Status;
-
-    #[test]
-    fn ping_me_baby() {
-      let client = Client::new(create_app()).expect("valid rocket instance");
-
-      let mut response = client.get("/ping").dispatch();
-
-      assert_eq!(response.status(), Status::Ok);
-      assert_eq!(response.body_string(), Some("pong".into()));
-    }
-}
+#[cfg(test)] mod tests;

--- a/metrix/src/tests.rs
+++ b/metrix/src/tests.rs
@@ -1,0 +1,13 @@
+use super::create_app;
+use rocket::local::Client;
+use rocket::http::Status;
+
+#[test]
+fn ping_me_baby() {
+  let client = Client::new(create_app()).expect("valid rocket instance");
+
+  let mut response = client.get("/ping").dispatch();
+
+  assert_eq!(response.status(), Status::Ok);
+  assert_eq!(response.body_string(), Some("pong".into()));
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}"
+echo "DATABASE_URL: ${DATABASE_URL}"
+
+cd metrix
+
+cargo test


### PR DESCRIPTION
**In this patch:**

- refactored app code to be in a separate module (un-necessarily...but maybe it is still better); in order to do component tests, the creation of the app instance is done via a factory method.
- added a test module for writing API tests; currently only tests `/ping`

**Extra notes:**

- didn't add more tests because `cargo test` runs tests in parallel. And right now there's no good way of scoping `Metric`s to a test. In the future if we implement multi-tenency, we could leverage it for scoping tests. Otherwise, we can also revisit it once the query parser is ready.
- cargo supports unit tests, and integrations tests; this implementation is using unit tests (tests are in the same directory as the source/`src`). The reason why we're doing unit tests is because you cannot import modules inside of integration tests for binary projects. You'd have to just call the binary using stdin and read the output via stdout; this seemed obtuse so I didn't go forward with this. Alternative as to turn it into a library, so then the entire app (based on my reading...) could be imported and then be tested as-is. That being said, I don't think the current structure is particularly bad...your thoughts?
- also, based on pre-lim reading, people are suggesting that db interactions be mocked out when doing unit testing. The arguments are similar to what I've heard for even python apps. I am not convinced, so once me move on to phase 2, I think I'll continue with the full db integrated test once isolation problem is solved. Unless someone disagrees...