### PR TITLE
Add query string `q` to GET `/metrics`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 metrix/target
+.cargo/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+metrix/target

--- a/metrix/Cargo.lock
+++ b/metrix/Cargo.lock
@@ -17,6 +17,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +404,18 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lexical-core"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +463,7 @@ dependencies = [
  "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_cli 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -532,6 +553,21 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -806,6 +842,14 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +866,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -864,6 +921,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "state"
 version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "static_assertions"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1129,6 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
@@ -1172,6 +1235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+"checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -1186,6 +1250,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mysqlclient-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7e9637d93448044078aaafea7419aed69d301b4a12bcc4aa0ae856eb169bef85"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+"checksum nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
 "checksum notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "199628fc33b21bc767baa057490b00b382ecbae030803a7b36292422d15b778b"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -1215,15 +1281,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0fa5c1392135adc0f96a02ba150ac4c765e27c58dbfd32aa40678e948f6e56f"
 "checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+"checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/metrix/Cargo.toml
+++ b/metrix/Cargo.toml
@@ -15,3 +15,4 @@ chrono = { version = "0.4.9", features = ["serde"] }
 diesel = { version = "1.0.0", features = ["postgres", "serde_json", "chrono"] }
 diesel_migrations = "1.4.0"
 diesel_cli = { version = "1.4.0", features = ["postgres"] }
+nom = "5.0.1"

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -3,6 +3,7 @@
 #[macro_use] extern crate diesel;
 #[macro_use] extern crate serde;
 #[macro_use] extern crate diesel_migrations;
+#[macro_use] extern crate nom;
 extern crate chrono;
 extern crate rocket_contrib;
 extern crate serde_json;
@@ -13,6 +14,7 @@ pub mod lib;
 pub mod models;
 pub mod schema;
 pub mod app;
+pub mod parser;
 
 use lib::establish_connection;
 

--- a/metrix/src/parser.rs
+++ b/metrix/src/parser.rs
@@ -1,0 +1,176 @@
+#[macro_use]
+extern crate nom;
+
+use std::str;
+use std::fmt;
+
+use nom::{
+    character::is_alphanumeric,
+    character::complete::{digit1 as digit, multispace1 as multispace},
+};
+
+pub struct Expression {
+    left: Box<ExpressionType>,
+    operator: String,
+    right: Box<ExpressionType>,
+}
+
+
+pub enum ExpressionType {
+    OuterExpression(Expression),
+    BaseExpression(BaseExpression),
+}
+
+pub struct BaseExpression {
+    field: String,
+    comparator: String,
+    value: String,
+}
+
+pub fn parse_query_string(input: String) -> Result<ExpressionType, &'static str> {
+    match root_expression(input.into_bytes()) {
+        Ok((_, o)) => Ok(o),
+        Err(_) => Err("Failed to parse query string"),
+    }
+}
+
+impl fmt::Display for ExpressionType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ExpressionType::OuterExpression(outer_expression) => write!(f, "{}", outer_expression),
+            ExpressionType::BaseExpression(base_expression) => write!(f, "{}", base_expression),
+        }
+    }
+}
+
+impl fmt::Display for Expression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        write!(f, "{}", self.left)?;
+        write!(f, " ")?;
+        write!(f, "{}", self.operator)?;
+        write!(f, " ")?;
+        write!(f, "{}", self.right)?;
+        write!(f, ")")
+    }
+}
+
+impl fmt::Display for BaseExpression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        write!(f, "{}", self.field)?;
+        write!(f, " ")?;
+        write!(f, "{}", self.comparator)?;
+        write!(f, " ")?;
+        write!(f, "{}", self.value)?;
+        write!(f, ")")
+    }
+}
+
+named!(root_expression<ExpressionType>,
+    complete!(expression)
+);
+
+named!(expression<ExpressionType>,
+    alt!(
+        do_parse!(
+            left: base_expression >>
+            multispace >>
+            tag_no_case!("or") >>
+            multispace >>
+            right: expression >>
+            (ExpressionType::OuterExpression(
+                Expression {
+                    operator: "or".to_string(),
+                    left: Box::new(left),
+                    right: Box::new(right),
+                }
+            ))
+        )
+        | and_expression
+        | base_expression
+    )
+);
+
+named!(and_expression<ExpressionType>,
+    do_parse!(
+        left: base_expression >>
+        multispace >>
+        tag_no_case!("and") >>
+        multispace >>
+        right: expression >>
+        (ExpressionType::OuterExpression(
+            Expression {
+                operator: "and".to_string(),
+                left: Box::new(left),
+                right: Box::new(right),
+            }
+        ))
+    )
+);
+
+named!(base_expression<ExpressionType>,
+    do_parse!(
+        field: parameter_name >>
+        opt_multispace >>
+        comparator: comparison_operator >>
+        opt_multispace >>
+        value: parameter_value >>
+        (ExpressionType::BaseExpression(
+            BaseExpression {
+                field: str::from_utf8(field).unwrap().to_string(),
+                comparator: str::from_utf8(comparator).unwrap().to_string(),
+                value: value,
+            }
+        ))
+    )
+);
+
+named!(comparison_operator,
+    alt!(
+          do_parse!(op: tag_no_case!("<=") >> (op))
+        | do_parse!(op: tag_no_case!(">=") >> (op))
+        | do_parse!(op: tag!("=") >> (op))
+        | do_parse!(op: tag!("<") >> (op))
+        | do_parse!(op: tag!(">") >> (op))
+    )
+);
+
+named!(parameter_name,
+    do_parse!(
+        param: take_while1!(is_sql_identifier) >>
+        (param)
+    )
+);
+
+named!(parameter_value<String>,
+    alt!(
+          do_parse!(
+              s: digit >>
+              tag!(".") >>
+              e: digit >>
+              (
+                format!("{}.{}",
+                    str::from_utf8(s).unwrap().to_string(),
+                    str::from_utf8(e).unwrap().to_string(),
+                )
+              )
+          )
+        | do_parse!(
+              d: digit >>
+              (str::from_utf8(d).unwrap().to_string())
+          )
+        | do_parse!(
+            literal: delimited!(opt!(tag!("\"")), take_until!("\""), opt!(tag!("\""))) >>
+            (format!("\"{}\"", str::from_utf8(literal).unwrap().to_string()))
+        )
+    )
+);
+
+named!(opt_multispace<Option<&[u8]>>,
+    opt!(multispace)
+);
+
+fn is_sql_identifier(chr: u8) -> bool {
+    is_alphanumeric(chr) || chr == '_' as u8 || chr == '.' as u8
+}

--- a/metrix/src/tests.rs
+++ b/metrix/src/tests.rs
@@ -2,6 +2,8 @@ use super::create_app;
 use rocket::local::Client;
 use rocket::http::Status;
 
+use crate::parser::parse_query_string;
+
 #[test]
 fn ping_me_baby() {
   let client = Client::new(create_app()).expect("valid rocket instance");
@@ -10,4 +12,151 @@ fn ping_me_baby() {
 
   assert_eq!(response.status(), Status::Ok);
   assert_eq!(response.body_string(), Some("pong".into()));
+}
+
+#[test]
+fn parse_query_string_single_expression_integer_value() {
+  let query_string = "data.user.id = 625";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(CAST (data->'user'->>'id' AS INTEGER) = 625)");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_string_value() {
+  let query_string = "data.user.name = 'Billiam'";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(data->'user'->>'name' = 'Billiam')");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_non_json_field() {
+  let query_string = "metric_name = 'CREATE USER'";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(metric_name = 'CREATE USER')");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_multiple_expression_with_and() {
+  let query_string = "metric_name = 'CREATE USER' and body.id = 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "((metric_name = 'CREATE USER') and (CAST (body->>'id' AS INTEGER) = 12))");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_multiple_expression_with_or() {
+  let query_string = "metric_name = 'CREATE USER' or metric_name = 'UPDATE USER' and body.id = 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(
+        format!("{}", o),
+        "((metric_name = 'CREATE USER') or ((metric_name = 'UPDATE USER') and (CAST (body->>'id' AS INTEGER) = 12)))"
+      );
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_less_than_operator() {
+  let query_string = "data.user.id < 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(CAST (data->'user'->>'id' AS INTEGER) < 12)");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_greater_than_operator() {
+  let query_string = "data.user.id > 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(CAST (data->'user'->>'id' AS INTEGER) > 12)");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_less_than_equals_operator() {
+  let query_string = "data.user.id <= 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(CAST (data->'user'->>'id' AS INTEGER) <= 12)");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_query_string_single_expression_greater_than_equals_operator() {
+  let query_string = "data.user.id >= 12";
+
+  let parsed_query = parse_query_string(query_string.to_string());
+
+  match parsed_query {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "(CAST (data->'user'->>'id' AS INTEGER) >= 12)");
+    },
+    Err(_) => {
+      panic!("Unable to parse query string")
+    },
+  }
 }


### PR DESCRIPTION
The query string `q` is of the format:
	body.value = 1 and event = "CREATE" or body.count >= 100

It is parsed and then used to generate a part of a postgres `WHERE`
clause that is used to filter the list of metrics.

NW