### PR TITLE
Add `/metrics/<aggregate>` route and implement for count

### DIFF
--- a/metrix/src/models.rs
+++ b/metrix/src/models.rs
@@ -1,6 +1,25 @@
 use super::schema::metrics;
 use serde_json;
 use chrono::naive::NaiveDateTime;
+use diesel::sql_types::*;
+
+#[derive(Serialize, Deserialize, Queryable, QueryableByName)]
+pub struct Bucket {
+    #[sql_type = "BigInt"]
+    pub value: i64,
+    #[sql_type = "Integer"]
+    pub bucket: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Buckets {
+    pub buckets: Vec<Bucket>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BucketedData {
+    pub data: Buckets,
+}
 
 #[derive(Serialize, Deserialize, Queryable, QueryableByName)]
 #[table_name="metrics"]


### PR DESCRIPTION
Added new route for performing aggregations on a filterable
list of metrics. In this pass, it allows for normal filtering,
but only aggragates with counts.

A request to this enpoint is of the form:

GET /metrics/count?start_datetime=2020-01-01T:00:00:00
&end_datetime=2020-01-02T00:00:00&bucket_count=4

On a successful request, a list of buckets is returned, of the
format:

```
{
   "buckets": [
	{ "result": 6, "bucket": 0 },
        { "result": 2, "bucket": 5 ),
        ...
    ]
}
```

for all non-empty buckets.

NW