### PR TITLE
Pad `/metrics/<aggregate>` bucketed results with empty buckets

### DIFF
--- a/metrix/src/models.rs
+++ b/metrix/src/models.rs
@@ -3,12 +3,18 @@ use serde_json;
 use chrono::naive::NaiveDateTime;
 use diesel::sql_types::*;
 
-#[derive(Serialize, Deserialize, Queryable, QueryableByName)]
-pub struct Bucket {
+#[derive(Queryable, QueryableByName)]
+pub struct BucketResult {
     #[sql_type = "BigInt"]
     pub value: i64,
     #[sql_type = "Integer"]
-    pub bucket: i32,
+    pub bucket_index: i32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Bucket {
+    pub value: i64,
+    pub bucket: NaiveDateTime,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Currently, when the endpoint returns a list of buckets, it omits
empty buckets entirely. Now, it fills in the empty buckets with
the value as `0`.

GET /metrics/count?start_datetime=...&end_datetime=...&bucket_count=4

```
{
    "data": {
        "buckets": [
            { value: 12, bucket: '2019-01-01T00:00:00'},
            { value: 12, bucket: '2019-06-01T00:00:00'},
            { value: 12, bucket: '2019-11-01T00:00:00'},
            { value: 12, bucket: '2020-04-01T00:00:00'}
        ]
    }
}
```

NW