### PR TITLE
Add aggregation functionality for min, max, avg, and sum

### DIFF
--- a/metrix/src/models.rs
+++ b/metrix/src/models.rs
@@ -5,15 +5,15 @@ use diesel::sql_types::*;
 
 #[derive(Queryable, QueryableByName)]
 pub struct BucketResult {
-    #[sql_type = "BigInt"]
-    pub value: i64,
+    #[sql_type = "Double"]
+    pub value: f64,
     #[sql_type = "Integer"]
     pub bucket_index: i32,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Bucket {
-    pub value: i64,
+    pub value: f64,
     pub bucket: NaiveDateTime,
 }
 

--- a/metrix/src/tests.rs
+++ b/metrix/src/tests.rs
@@ -3,6 +3,7 @@ use rocket::local::Client;
 use rocket::http::Status;
 
 use crate::parser::parse_query_string;
+use crate::parser::parse_parameter_name;
 
 #[test]
 fn ping_me_baby() {
@@ -157,6 +158,53 @@ fn parse_query_string_single_expression_greater_than_equals_operator() {
     },
     Err(_) => {
       panic!("Unable to parse query string")
+    },
+  }
+}
+
+#[test]
+fn parse_parameter_name_no_nesting() {
+  let metric_name = "data";
+
+  let parsed_name = parse_parameter_name(metric_name.to_string());
+
+  match parsed_name {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "data");
+    },
+    Err(_) => {
+      panic!("Unable to parse parameter name")
+    },
+  }
+}
+
+#[test]
+fn parse_parameter_name_single_nested_parameter() {
+  let metric_name = "data.height";
+
+  let parsed_name = parse_parameter_name(metric_name.to_string());
+
+  match parsed_name {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "data->>'height'");
+    },
+    Err(_) => {
+      panic!("Unable to parse parameter name")
+    },
+  }
+}
+
+#[test]
+fn parse_parameter_name_heavily_nested_parameter() {
+  let metric_name = "one.two.three.four.five.six.seven.eight.nine.ten";
+
+  let parsed_name = parse_parameter_name(metric_name.to_string());
+  match parsed_name {
+    Ok(o) => {
+      assert_eq!(format!("{}", o), "one->'two'->'three'->'four'->'five'->'six'->'seven'->'eight'->'nine'->>'ten'");
+    },
+    Err(_) => {
+      panic!("Unable to parse parameter name")
     },
   }
 }


### PR DESCRIPTION
This allows for queries to the `/metrics/<aggregation>` to specify
any of the above mentioned values (min, avg, max, or sum) and for that
operation to be performed on the resulting filtered data.

So, requests of the form:

GET
`/metrics/<aggregation>?bucket_count=x&start_datetime=xxx&end_datetime=xxx
&q=xxx&metric_name=xxx`

will return

```
{
	"data": {
		"buckets": [
			{"value": x, "bucket": "2019-01-01T00:00:00"},
			...
		]
	}
}
```

where `metric_name` specifies the path to the value in the metric data
to perform the aggregate on (data.nested_object.value), and `value` is the resulting aggregate for
the given bucket.

NW