### PR TITLE
Refactor application directory structure

### DIFF
--- a/metrix/src/db.rs
+++ b/metrix/src/db.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+use diesel::prelude::*;
+
+pub fn establish_connection() -> PgConnection {
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}

--- a/metrix/src/lib.rs
+++ b/metrix/src/lib.rs
@@ -1,10 +1,24 @@
-use diesel::prelude::*;
+#![feature(proc_macro_hygiene, decl_macro)]
 
-use std::env;
+#[macro_use] extern crate rocket;
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate serde;
 
-pub fn establish_connection() -> PgConnection {
-    let database_url = env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+pub mod db;
+pub mod models;
+pub mod parser;
+pub mod schema;
+
+mod routes;
+
+pub fn create_app() -> rocket::Rocket {
+    rocket::ignite()
+        .mount("/ping", routes![
+            routes::ping::ping,
+        ])
+        .mount("/metrics", routes![
+            routes::metrics::create_metric_route,
+            routes::metrics::query_metric_route,
+            routes::metrics::aggregate_metrics_route,
+        ])
 }

--- a/metrix/src/main.rs
+++ b/metrix/src/main.rs
@@ -1,26 +1,10 @@
-#![feature(proc_macro_hygiene, decl_macro)]
-#[macro_use] extern crate rocket;
-#[macro_use] extern crate diesel;
-#[macro_use] extern crate serde;
 #[macro_use] extern crate diesel_migrations;
-#[macro_use] extern crate nom;
-extern crate chrono;
-extern crate rocket_contrib;
-extern crate serde_json;
-
 embed_migrations!();
 
-pub mod lib;
-pub mod models;
-pub mod schema;
-pub mod app;
-pub mod parser;
-
-use lib::establish_connection;
-
-pub fn create_app() -> rocket::Rocket {
-  app::create_app()
-}
+use metrix::{
+	db::establish_connection,
+	create_app,
+};
 
 fn main() {
     println!("### Enter the Metrix ###");
@@ -32,5 +16,3 @@ fn main() {
 
     create_app().launch();
 }
-
-#[cfg(test)] mod tests;

--- a/metrix/src/models.rs
+++ b/metrix/src/models.rs
@@ -1,7 +1,10 @@
-use super::schema::metrics;
-use serde_json;
 use chrono::naive::NaiveDateTime;
+
 use diesel::sql_types::*;
+use serde_json;
+
+use crate::schema::metrics;
+
 
 #[derive(Queryable, QueryableByName)]
 pub struct BucketResult {

--- a/metrix/src/routes/mod.rs
+++ b/metrix/src/routes/mod.rs
@@ -1,0 +1,2 @@
+pub mod ping;
+pub mod metrics;

--- a/metrix/src/routes/ping.rs
+++ b/metrix/src/routes/ping.rs
@@ -1,0 +1,4 @@
+#[get("/")]
+pub fn ping() -> &'static str {
+    "pong"
+}

--- a/metrix/tests/common.rs
+++ b/metrix/tests/common.rs
@@ -1,0 +1,7 @@
+use rocket::local::Client;
+
+use metrix::create_app;
+
+pub fn create_app_client() -> Client {
+	Client::new(create_app()).expect("valid rocket instance")
+}

--- a/metrix/tests/parser.rs
+++ b/metrix/tests/parser.rs
@@ -1,19 +1,6 @@
-use super::create_app;
-use rocket::local::Client;
-use rocket::http::Status;
+use metrix::parser::parse_query_string;
+use metrix::parser::parse_parameter_name;
 
-use crate::parser::parse_query_string;
-use crate::parser::parse_parameter_name;
-
-#[test]
-fn ping_me_baby() {
-  let client = Client::new(create_app()).expect("valid rocket instance");
-
-  let mut response = client.get("/ping").dispatch();
-
-  assert_eq!(response.status(), Status::Ok);
-  assert_eq!(response.body_string(), Some("pong".into()));
-}
 
 #[test]
 fn parse_query_string_single_expression_integer_value() {

--- a/metrix/tests/ping.rs
+++ b/metrix/tests/ping.rs
@@ -1,0 +1,15 @@
+mod common;
+
+use rocket::http::Status;
+
+use common::create_app_client;
+
+#[test]
+fn ping_me_baby() {
+  let client = create_app_client();
+
+  let mut response = client.get("/ping").dispatch();
+
+  assert_eq!(response.status(), Status::Ok);
+  assert_eq!(response.body_string(), Some("pong".into()));
+}


### PR DESCRIPTION
Seperated modules out for readability's sake.

Namely, moved each route into it's own file, cut down on global imports,
sorted imports/dependenies, and split out tests.

NW