### PR TITLE
Get json paths for metric

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,4 @@
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}"
 echo "DATABASE_URL: ${DATABASE_URL}"
 
-cd metrix
-
 cargo run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,6 @@ pub fn create_app() -> rocket::Rocket {
             routes::metrics::create_metric_route,
             routes::metrics::query_metric_route,
             routes::metrics::aggregate_metrics_route,
+            routes::metrics::query_metric_params
         ])
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -30,6 +30,16 @@ pub struct BucketedData {
     pub data: Buckets,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct MetricDataParamNames {
+    pub parameter_names: Vec<String>
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MetricDataParams {
+    pub data: MetricDataParamNames
+}
+
 #[derive(Serialize, Deserialize, Queryable, QueryableByName)]
 #[table_name="metrics"]
 pub struct Metric {

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -100,7 +100,7 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
 }
 
 fn get_paths_from_json(data: &serde_json::Value) -> Vec<String> {
-    let mut output = vec![vec![]];
+    let mut output: Vec<Vec<String>> = vec![];
     let current_path = vec![];
     deep_keys(&data, current_path, &mut output);
 
@@ -118,7 +118,7 @@ fn deep_keys(value: &serde_json::Value, current_path: Vec<String>, output: &mut 
             for (k, v) in map {
                 let mut new_path = current_path.clone();
                 new_path.push(k.to_owned());
-                deep_keys(v,  new_path, output);
+                deep_keys(v, new_path, output);
             }
         },
         // Value::Array(array) => {

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -57,6 +57,20 @@ pub fn query_metric_route(
     Ok(Json(results))
 }
 
+#[get("/search_parameters?<metric_name>")]
+pub fn query_metric_params(metric_name: &RawStr) -> Json<MetricDataParams> {
+    let mut vec = Vec::new();
+    vec.push(String::from("a"));
+    vec.push(String::from("b"));
+    vec.push(String::from("c"));
+
+    Json(MetricDataParams {
+        data: MetricDataParamNames {
+            parameter_names: vec
+        }
+    })
+}
+
 #[get("/<aggregation>?<offset>&<start_datetime>&<end_datetime>&<q>&<bucket_count>&<metric_name>")]
 pub fn aggregate_metrics_route(
     aggregation: Option<&RawStr>,

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -84,14 +84,15 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
     }
 
     println!("metric_name found: {}", query_result[0].data);
+    let paths: Vec<String>;
 
-    let paths = get_paths_from_json(&query_result[0].data);
+    if query_result[0].data.is_object() {
+        paths = get_paths_from_json(&query_result[0].data);
+    } else {
+        paths = vec![];
+    }
 
-    // let mut vec = Vec::new();
-    // vec.push(String::from("a"));
-    // vec.push(String::from("b"));
-    // vec.push(String::from("c"));
-
+    // let paths = get_paths_from_json(&query_result[0].data);
     Ok(Json(MetricDataParams {
         data: MetricDataParamNames {
             parameter_names: paths

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -6,7 +6,6 @@ use diesel::sql_query;
 use rocket::http::RawStr;
 use rocket::response::status::BadRequest;
 use rocket_contrib::json::Json;
-// use serde_json::Value;
 
 use crate::db::establish_connection;
 use crate::models::*;
@@ -74,7 +73,7 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
     }
 
     let query_string = format!("SELECT * FROM metrics WHERE metric_name = '{}' ORDER BY id DESC LIMIT 1", parsed_metric_name);
-    println!("### query_string: {}", query_string);
+
     let query_result = sql_query(query_string)
         .load::<Metric>(&db_conn)
         .expect("Error loading metrics");
@@ -83,9 +82,7 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
         return Err(BadRequest(Some("metric name does not exist...".to_string())));
     }
 
-    println!("metric_name found: {}", query_result[0].data);
     let paths: Vec<String>;
-
     if query_result[0].data.is_object() {
         paths = get_paths_from_json(&query_result[0].data);
     } else {


### PR DESCRIPTION
**In this PR:**
- Added a metrics/search_parameters?metric_name endpoint
- returns list of json paths available for a given metric name
- the json paths can then be used for aggregation metrics

## Sample Request/Responses

### Empty data query 

`curl http://localhost:8000/metrics/search_parameters?metric_name=nothing`

```
// HTTP 200

{
    "data": {
        "parameter_names": []
    }
}
```

### Nested data query

*note: it selects the "newest" entry for a given metric name

`curl 'http://localhost:8000/metrics/search_parameters?metric_name=who'`

```
// HTTP 200

{
  "data": {
    "parameter_names": [
      "cloud",
      "cluster",
      "decimal_revision",
      "latency",
      "nested",
      "nested.level_1",
      "nested.level_1.level_2",
      "nested.level_1.level_2.level_3",
      "release",
      "revision"
    ]
  }
}
```

### Non-existent metric_name query

`curl 'http://localhost:8000/metrics/search_parameters?metric_name=doesnotexist'`

```
// HTTP 400

"metric name does not exist..."
```


### Entries in DB

```
metrix=# SELECT metric_name, data FROM metrics WHERE id > 5 LIMIT 10;
 metric_name |                                                                             data
-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------
 who         | {"cloud":"gcp","cluster":"alpha-1","decimal_revision":9.0,"latency":3,"release":"1911.1.0","revision":9}
 dat         | {"cloud":"gcp","cluster":"alpha-1","decimal_revision":9.0,"latency":5,"release":"1911.1.0","revision":9}
 who         | {"cloud":"gcp","cluster":"alpha-1","decimal_revision":9.0,"latency":9,"nested":{"level_1":{"level_2":{"level_3":"done"}}},"release":"1911.1.0","revision":9}
 nothing     | {}
```