### PR TITLE
added search_metric_names endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub fn create_app() -> rocket::Rocket {
             routes::metrics::create_metric_route,
             routes::metrics::query_metric_route,
             routes::metrics::aggregate_metrics_route,
-            routes::metrics::query_metric_params
+            routes::metrics::query_metric_params,
+            routes::metrics::search_metric_names
         ])
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,12 @@ pub struct BucketResult {
     pub bucket_index: i32,
 }
 
+#[derive(Queryable, QueryableByName)]
+pub struct MetricNameResult {
+    #[sql_type = "Text"]
+    pub metric_name: String
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Bucket {
     pub value: f64,
@@ -38,6 +44,16 @@ pub struct MetricDataParamNames {
 #[derive(Serialize, Deserialize)]
 pub struct MetricDataParams {
     pub data: MetricDataParamNames
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MetricNames {
+    pub metric_names: Vec<String>
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MetricNameParams {
+    pub data: MetricNames
 }
 
 #[derive(Serialize, Deserialize, Queryable, QueryableByName)]


### PR DESCRIPTION
**For future:**
we probably wanna index the `metrc_name` field

### nothing found

```
curl 'http://localhost:8000/metrics/search_metric_names?q=doesnotexist'

{
  "data": {
    "metric_names": []
  }
}
```

### something found

```
curl 'http://localhost:8000/metrics/search_metric_names?q=o'

{
  "data": {
    "metric_names": [
      "who",
      "nothing"
    ]
  }
}
```

### empty search

```
curl 'http://localhost:8000/metrics/search_metric_names?q='

{
  "data": {
    "metric_names": [
      "who",
      "dat",
      "nothing"
    ]
  }
}

(first 20 hits)
```