### PR TITLE
JSON error response

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -2,9 +2,9 @@ use chrono::naive::NaiveDateTime;
 
 use diesel::sql_types::*;
 use serde_json;
+use rocket_contrib::json::Json;
 
 use crate::schema::metrics;
-
 
 #[derive(Queryable, QueryableByName)]
 pub struct BucketResult {
@@ -71,4 +71,24 @@ pub struct Metric {
 pub struct NewMetric {
     pub metric_name: String,
     pub data: serde_json::Value,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ErrorObject {
+    pub message: String,
+    // pub code: usize,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Error {
+    pub errors: Vec<ErrorObject>,
+}
+
+#[derive(Responder, Debug)]
+pub enum ErrorResponder {
+    #[response(status = 400, content_type = "json")]
+    UserError(Json<Error>),
+
+    #[response(status = 500, content_type = "json")]
+    FatalError(Json<Error>),
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -87,8 +87,8 @@ pub struct Error {
 #[derive(Responder, Debug)]
 pub enum ErrorResponder {
     #[response(status = 400, content_type = "json")]
-    UserError(Json<Error>),
+    BadRequest(Json<Error>),
 
     #[response(status = 500, content_type = "json")]
-    FatalError(Json<Error>),
+    InternalServerError(Json<Error>),
 }

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -58,7 +58,7 @@ pub fn query_metric_route(
 }
 
 #[get("/search_metric_names?<q>")]
-pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, BadRequest<String>> {
+pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, ErrorResponder> {
     let db_conn = establish_connection();
     let parsed_query :String;
 
@@ -67,7 +67,9 @@ pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, BadRequ
             parsed_query = query;
         },
         Err(_) => {
-            return Err(BadRequest(Some("bad query...".to_string())));
+            return Err(ErrorResponder::UserError(Json(Error {
+                errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
+            })));
         }
     }
 

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -43,7 +43,7 @@ pub fn query_metric_route(
             filter_clause = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::UserError(Json(Error {
+            return Err(ErrorResponder::BadRequest(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
             })));
         },
@@ -69,7 +69,7 @@ pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, ErrorRe
             parsed_query = query;
         },
         Err(_) => {
-            return Err(ErrorResponder::UserError(Json(Error {
+            return Err(ErrorResponder::BadRequest(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
             })));
         }
@@ -99,7 +99,7 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
             parsed_metric_name = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::UserError(Json(Error {
+            return Err(ErrorResponder::BadRequest(Json(Error {
                 errors: vec![ErrorObject { message: "bad `metric_name` param".to_string() }]
             })));
         }
@@ -112,7 +112,7 @@ pub fn query_metric_params(metric_name: &RawStr) -> Result<Json<MetricDataParams
         .expect("Error loading metrics");
 
     if query_result.len() == 0 {
-        return Err(ErrorResponder::UserError(Json(Error {
+        return Err(ErrorResponder::BadRequest(Json(Error {
             errors: vec![ErrorObject { message: "no entry found for `metric_name`".to_string() }]
         })));
     }
@@ -176,7 +176,7 @@ pub fn aggregate_metrics_route(
 ) -> Result<Json<BucketedData>, ErrorResponder> {
 
     if !start_datetime.is_some() || !end_datetime.is_some() {
-        return Err(ErrorResponder::UserError(Json(Error {
+        return Err(ErrorResponder::BadRequest(Json(Error {
             errors: vec![ErrorObject { message: "You need to send start_datetime and end_datetime".to_string() }]
         })));
     }
@@ -189,7 +189,7 @@ pub fn aggregate_metrics_route(
             filter_clause = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::UserError(Json(Error {
+            return Err(ErrorResponder::BadRequest(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
             })));
         },
@@ -205,7 +205,7 @@ pub fn aggregate_metrics_route(
                     parameter_name = format!("{}", o).to_string();
                 },
                 Err(_) => {
-                    return Err(ErrorResponder::UserError(Json(Error {
+                    return Err(ErrorResponder::BadRequest(Json(Error {
                         errors: vec![ErrorObject {
                             message: "malformatted `metric_data_path` param".to_string()
                         }]
@@ -235,7 +235,7 @@ pub fn aggregate_metrics_route(
                 aggregate = o;
             },
             Err(_) => {
-                return Err(ErrorResponder::UserError(Json(Error {
+                return Err(ErrorResponder::BadRequest(Json(Error {
                     errors: vec![ErrorObject {
                         message: "unknown aggregate type".to_string()
                     }]
@@ -243,7 +243,7 @@ pub fn aggregate_metrics_route(
             }
         }
     } else {
-        return Err(ErrorResponder::UserError(Json(Error {
+        return Err(ErrorResponder::BadRequest(Json(Error {
             errors: vec![ErrorObject {
                 message: "No aggregate type provided".to_string()
             }]


### PR DESCRIPTION
I spent DAYS scratching my head looking for a solution, before finally ending up on this clean implementation via: https://github.com/SergioBenitez/Rocket/issues/1031#issuecomment-502492448

The docs covered "making a custom responder" but not really with the details I was missing. For example, not having to make a new error type for every status code. And all the weird Responder implementation errors I was getting with my attempt; it was all very opaque and frustrating. It's also a little weird because the solution I found in that issue, is _very_ close to what I was trying to scrap together...and honestly makes a tonne of sense given what I had read up to this point, but wow man...why isn't the tutorial/guide include this snippet!? Honestly...

```
> curl -i 'http://localhost:8000/metrics/search_parameters?metric_name=NULL'
HTTP/1.1 400 Bad Request
Content-Type: application/json
Server: Rocket
Content-Length: 59
Date: Wed, 06 May 2020 05:47:28 GMT

{"errors":[{"message":"no entry found for `metric_name`"}]}
```

```
> curl -i 'http://localhost:8000/metrics/sum?search_metric_names=1&bucket_count=1'
HTTP/1.1 400 Bad Request
Content-Type: application/json
Server: Rocket
Content-Length: 75
Date: Wed, 06 May 2020 05:48:21 GMT

{"errors":[{"message":"You need to send start_datetime and end_datetime"}]}
```