### PR TITLE
Add db pooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: nwoodger/rust-rocket
         environment:
-          DB_HOST: db
+          DB_HOST: localhost
           DB_PORT: 5432
           POSTGRES_USER: user
           POSTGRES_PASSWORD: stompy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,17 @@ jobs:
   build:
     docker:
       - image: nwoodger/rust-rocket
+        environment:
+          DB_HOST: db
+          DB_PORT: 5432
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: stompy
+          POSTGRES_DB: metrix
+      - image: postgres
+        environment:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: stompy
+          POSTGRES_DB: metrix
     steps:
       - checkout
       - run: ./test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +198,7 @@ dependencies = [
  "libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mysqlclient-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -430,6 +439,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +633,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pear"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +732,16 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scheduled-thread-pool 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -814,11 +863,25 @@ name = "rocket_contrib"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_contrib_codegen"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -867,6 +930,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -1211,6 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
 "checksum devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
@@ -1244,6 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+"checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -1262,6 +1340,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
+"checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+"checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 "checksum pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c26d2b92e47063ffce70d3e3b1bd097af121a9e0db07ca38a6cc1cf0cc85ff25"
 "checksum pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "336db4a192cc7f54efeb0c4e11a9245394824cc3bcbd37ba3ff51240c35d7a6e"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
@@ -1273,6 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1497e40855348e4a8a40767d8e55174bce1e445a3ac9254ad44ad468ee0485af"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1285,12 +1366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
 "checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
 "checksum rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0fa5c1392135adc0f96a02ba150ac4c765e27c58dbfd32aa40678e948f6e56f"
+"checksum rocket_contrib_codegen 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ab5e6e10ee153cdd6831348ce2c32a6323fb919a0254dbb829e0efe87c12d0d"
 "checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+"checksum scheduled-thread-pool 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0988d7fdf88d5e5fcf5923a0f1e8ab345f3e98ab4bc6bc45a2d5ff7f7458fbf6"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 rocket = "0.4.2"
-rocket_contrib = "0.4.2"
+rocket_contrib = { version = "0.4.2", features = ["diesel_postgres_pool"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.41"
 chrono = { version = "0.4.9", features = ["serde"] }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL:=help
-.PHONY: help server
+.PHONY: help server tests
 
 help: ## Show all the available make commands
 	@echo "\n======================================================================================================================================================================="

--- a/rocket.toml
+++ b/rocket.toml
@@ -5,3 +5,6 @@ port = 8000
 [development]
 address = "0.0.0.0"
 port = 8000
+
+[global.databases]
+postgres_db = { url = "replace-this-ROCKET_DATABASES-env-var", pool_size = 10 }

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,10 @@
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}"
+
+# Required for Database pooling configuration
+# https://api.rocket.rs/v0.4/rocket_contrib/databases/index.html
+export ROCKET_DATABASES="{postgres_db={url=\"${DATABASE_URL}\",pool_size=10}}"
+
 echo "DATABASE_URL: ${DATABASE_URL}"
+echo "ROCKET_DATABASES: ${ROCKET_DATABASES}"
 
 cargo run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use] extern crate rocket;
+#[macro_use] extern crate rocket_contrib;
 #[macro_use] extern crate diesel;
 #[macro_use] extern crate serde;
 
@@ -10,6 +11,11 @@ pub mod parser;
 pub mod schema;
 
 mod routes;
+
+// This registers your database with Rocket, returning a `Fairing` that can be `.attach`'d to your
+// Rocket application to set up a connection pool for it and automatically manage it for you.
+#[database("postgres_db")]
+pub struct DbConn(diesel::PgConnection);
 
 pub fn create_app() -> rocket::Rocket {
     rocket::ignite()
@@ -23,4 +29,5 @@ pub fn create_app() -> rocket::Rocket {
             routes::metrics::query_metric_params,
             routes::metrics::search_metric_names
         ])
+        .attach(DbConn::fairing())
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,6 @@ use chrono::naive::NaiveDateTime;
 
 use diesel::sql_types::*;
 use serde_json;
-use rocket_contrib::json::Json;
 
 use crate::schema::metrics;
 
@@ -82,13 +81,4 @@ pub struct ErrorObject {
 #[derive(Serialize, Debug)]
 pub struct Error {
     pub errors: Vec<ErrorObject>,
-}
-
-#[derive(Responder, Debug)]
-pub enum ErrorResponder {
-    #[response(status = 400, content_type = "json")]
-    BadRequest(Json<Error>),
-
-    #[response(status = 500, content_type = "json")]
-    InternalServerError(Json<Error>),
 }

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -33,7 +33,7 @@ pub fn query_metric_route(
     start_datetime: Option<&RawStr>,
     end_datetime: Option<&RawStr>,
     q: Option<&RawStr>,
-) -> Result<Json<Vec<Metric>>, ErrorResponder> {
+) -> Result<Json<Vec<Metric>>, BadRequest<Json<Error>>> {
     let filter_clause: String;
     let result = build_filter_clause(offset, start_datetime, end_datetime, q);
     match result {
@@ -41,9 +41,9 @@ pub fn query_metric_route(
             filter_clause = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::BadRequest(Json(Error {
+            return Err(BadRequest(Some(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
-            })));
+            }))));
         },
     }
 
@@ -58,7 +58,7 @@ pub fn query_metric_route(
 }
 
 #[get("/search_metric_names?<q>")]
-pub fn search_metric_names(db_conn: DbConn, q: &RawStr) -> Result<Json<MetricNameParams>, ErrorResponder> {
+pub fn search_metric_names(db_conn: DbConn, q: &RawStr) -> Result<Json<MetricNameParams>, BadRequest<Json<Error>>> {
     let parsed_query : String;
 
     match q.url_decode() {
@@ -66,9 +66,9 @@ pub fn search_metric_names(db_conn: DbConn, q: &RawStr) -> Result<Json<MetricNam
             parsed_query = query;
         },
         Err(_) => {
-            return Err(ErrorResponder::BadRequest(Json(Error {
+            return Err(BadRequest(Some(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
-            })));
+            }))));
         }
     }
 
@@ -86,7 +86,7 @@ pub fn search_metric_names(db_conn: DbConn, q: &RawStr) -> Result<Json<MetricNam
 }
 
 #[get("/search_parameters?<metric_name>")]
-pub fn query_metric_params(db_conn: DbConn, metric_name: &RawStr) -> Result<Json<MetricDataParams>, ErrorResponder> {
+pub fn query_metric_params(db_conn: DbConn, metric_name: &RawStr) -> Result<Json<MetricDataParams>, BadRequest<Json<Error>>> {
     let result = metric_name.url_decode();
     let parsed_metric_name: String;
 
@@ -95,9 +95,9 @@ pub fn query_metric_params(db_conn: DbConn, metric_name: &RawStr) -> Result<Json
             parsed_metric_name = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::BadRequest(Json(Error {
+            return Err(BadRequest(Some(Json(Error {
                 errors: vec![ErrorObject { message: "bad `metric_name` param".to_string() }]
-            })));
+            }))));
         }
     }
 
@@ -108,9 +108,9 @@ pub fn query_metric_params(db_conn: DbConn, metric_name: &RawStr) -> Result<Json
         .expect("Error loading metrics");
 
     if query_result.len() == 0 {
-        return Err(ErrorResponder::BadRequest(Json(Error {
+        return Err(BadRequest(Some(Json(Error {
             errors: vec![ErrorObject { message: "no entry found for `metric_name`".to_string() }]
-        })));
+        }))));
     }
 
     let paths: Vec<String>;
@@ -170,12 +170,12 @@ pub fn aggregate_metrics_route(
     q: Option<&RawStr>,
     bucket_count: i32,
     metric_data_path: Option<&RawStr>,
-) -> Result<Json<BucketedData>, ErrorResponder> {
+) -> Result<Json<BucketedData>, BadRequest<Json<Error>>> {
 
     if !start_datetime.is_some() || !end_datetime.is_some() {
-        return Err(ErrorResponder::BadRequest(Json(Error {
+        return Err(BadRequest(Some(Json(Error {
             errors: vec![ErrorObject { message: "You need to send start_datetime and end_datetime".to_string() }]
-        })));
+        }))));
     }
 
     let filter_clause: String;
@@ -185,9 +185,9 @@ pub fn aggregate_metrics_route(
             filter_clause = o;
         },
         Err(_) => {
-            return Err(ErrorResponder::BadRequest(Json(Error {
+            return Err(BadRequest(Some(Json(Error {
                 errors: vec![ErrorObject { message: "bad value for `q` param".to_string() }]
-            })));
+            }))));
         },
     }
 
@@ -201,11 +201,11 @@ pub fn aggregate_metrics_route(
                     parameter_name = format!("{}", o).to_string();
                 },
                 Err(_) => {
-                    return Err(ErrorResponder::BadRequest(Json(Error {
+                    return Err(BadRequest(Some(Json(Error {
                         errors: vec![ErrorObject {
                             message: "malformatted `metric_data_path` param".to_string()
                         }]
-                    })));
+                    }))));
                 },
             }
         }
@@ -231,19 +231,19 @@ pub fn aggregate_metrics_route(
                 aggregate = o;
             },
             Err(_) => {
-                return Err(ErrorResponder::BadRequest(Json(Error {
+                return Err(BadRequest(Some(Json(Error {
                     errors: vec![ErrorObject {
                         message: "unknown aggregate type".to_string()
                     }]
-                })));
+                }))));
             }
         }
     } else {
-        return Err(ErrorResponder::BadRequest(Json(Error {
+        return Err(BadRequest(Some(Json(Error {
             errors: vec![ErrorObject {
                 message: "No aggregate type provided".to_string()
             }]
-        })));
+        }))));
     }
 
     let query_string = format!(

--- a/src/routes/metrics.rs
+++ b/src/routes/metrics.rs
@@ -7,6 +7,7 @@ use rocket::http::RawStr;
 use rocket::response::status::BadRequest;
 use rocket_contrib::json::Json;
 
+use crate::DbConn;
 use crate::db::establish_connection;
 use crate::models::*;
 use crate::parser::parse_parameter_name;
@@ -60,9 +61,9 @@ pub fn query_metric_route(
 }
 
 #[get("/search_metric_names?<q>")]
-pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, ErrorResponder> {
-    let db_conn = establish_connection();
-    let parsed_query :String;
+pub fn search_metric_names(db_conn: DbConn, q: &RawStr) -> Result<Json<MetricNameParams>, ErrorResponder> {
+    // let db_conn = establish_connection();
+    let parsed_query : String;
 
     match q.url_decode() {
         Ok(query) => {
@@ -78,7 +79,7 @@ pub fn search_metric_names(q: &RawStr) -> Result<Json<MetricNameParams>, ErrorRe
     let query_string = format!("SELECT DISTINCT(metric_name) AS metric_name FROM metrics WHERE metric_name LIKE '%{}%' LIMIT 20", parsed_query);
 
     let query_result = sql_query(query_string)
-        .load::<MetricNameResult>(&db_conn)
+        .load::<MetricNameResult>(&*db_conn)
         .expect("Error loading metrics");
 
     Ok(Json(MetricNameParams {

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,7 @@
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DB_HOST}:${DB_PORT}/${POSTGRES_DB}"
+export ROCKET_DATABASES="{postgres_db={url=\"${DATABASE_URL}\",pool_size=10}}"
+
 echo "DATABASE_URL: ${DATABASE_URL}"
+echo "ROCKET_DATABASES: ${ROCKET_DATABASES}"
 
 cargo test


### PR DESCRIPTION
Instead of spinning up new db connection per request, reduce, reuse, recycle!

Since we don't compile config files, and there isn't a graceful way of adding ENV vars to `Rocket.toml`, I resorted to that ugly ugly config declaration as an ENV var.